### PR TITLE
hotfix: row attributes via server-side processing

### DIFF
--- a/js/core/core.draw.js
+++ b/js/core/core.draw.js
@@ -91,28 +91,30 @@ function _fnRowAttributes( row )
 	var data = row._aData;
 
 	if ( tr ) {
-		if ( data.DT_RowId ) {
-			tr.id = data.DT_RowId;
-		}
+		var tr = row.nTr;
+		var data = row._aData;
+	
+		if ( tr ) {
+			if ( data.DT_RowId ) {
+				tr.id = data.DT_RowId;
+			}
+	
+			if ( data.DT_RowClass ) {
+				// Remove any classes added by DT_RowClass before
+				var a = data.DT_RowClass.split(' ');
+				row.__rowc = row.__rowc ?
+					_unique( row.__rowc.concat( a ) ) :
+					a;
 
-		if ( data.DT_RowClass ) {
-			// Remove any classes added by DT_RowClass before
-			var a = data.DT_RowClass.split(' ');
-			row.__rowc = row.__rowc ?
-				_unique( row.__rowc.concat( a ) ) :
-				a;
+		                tr.classList.remove( row.__rowc.join(' ') );
+		                tr.classList.add( data.DT_RowClass );
+			}
 
-			$(tr)
-				.removeClass( row.__rowc.join(' ') )
-				.addClass( data.DT_RowClass );
-		}
-
-		if ( data.DT_RowAttr ) {
-			$(tr).attr( data.DT_RowAttr );
-		}
-
-		if ( data.DT_RowData ) {
-			$(tr).data( data.DT_RowData );
+			if ( data.DT_RowData ) {
+		                $.each( data.DT_RowData, function( attr, value ) {
+		                	return tr.setAttribute( 'data-' + attr, value );
+		                });
+			}
 		}
 	}
 }


### PR DESCRIPTION
Since `<tr>` element was existing only in memory and not in DOM tree at the moment of calling `_fnRowAttributes()` using `$(tr)` caused creation of a _copy_ of `<tr>` element and making data-attributes insertion in new `$(tr)` made no sense.
Fixed to use native JS methods to make necessary additions to the target row element.
Not able to prepare a demo for you right now, but if issue is not clear I will try to make some example.
